### PR TITLE
Support for Delphi XE2 and above

### DIFF
--- a/src-x86-binarymaster/rdpwrap.dpr
+++ b/src-x86-binarymaster/rdpwrap.dpr
@@ -73,7 +73,7 @@ const
 var
   INI: INIFile;
   LogFile: String = '\rdpwrap.txt';
-  bw: DWORD;
+  bw: {$if CompilerVersion>=16} NativeUInt {$else} DWORD {$endif};
   IsHooked: Boolean = False;
 
 // Unhooked import


### PR DESCRIPTION
I forgot about this other little change that was needed when I compiled with Delphi 10.  I also added the conditional so it still works as before with XE and below.

This is definitely the only other change I had to make.